### PR TITLE
Fix font download error during build

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -1,6 +1,5 @@
 import "../assets/scss/globals.scss";
 import "../assets/scss/theme.scss";
-import { Inter } from "next/font/google";
 import { siteConfig } from "@/config/site";
 import Providers from "@/provider/providers";
 import "simplebar-react/dist/simplebar.min.css";
@@ -9,7 +8,6 @@ import AuthProvider from "@/provider/auth.provider";
 import "flatpickr/dist/themes/light.css";
 import DirectionProvider from "@/provider/direction.provider";
 
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
   title: {

--- a/provider/providers.tsx
+++ b/provider/providers.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { Inter } from "next/font/google";
 import { useThemeStore } from "@/store";
 import { ThemeProvider } from "next-themes";
 import { cn } from "@/lib/utils";
@@ -8,7 +7,8 @@ import { Toaster } from "react-hot-toast";
 import { SonnToaster } from "@/components/ui/sonner";
 import { usePathname } from "next/navigation";
 
-const inter = Inter({ subsets: ["latin"] });
+// Use a generic sans-serif font to avoid network font downloads during build
+const inter = { className: "font-sans" } as const;
 const Providers = ({ children }: { children: React.ReactNode }) => {
   const { theme, radius } = useThemeStore();
   const location = usePathname();


### PR DESCRIPTION
## Summary
- remove `next/font` imports so build doesn't attempt to fetch fonts
- use a simple `font-sans` class for styling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a13e77258833382657770b6708e14