### PR TITLE
Update menu management dialogs

### DIFF
--- a/app/[lang]/(dashboard)/(settings)/(menus)/_components/dialog/confirm-dialog.tsx
+++ b/app/[lang]/(dashboard)/(settings)/(menus)/_components/dialog/confirm-dialog.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React, { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Icon } from "@iconify/react";
@@ -12,8 +13,8 @@ interface ConfirmDialogProps {
     class?: "primary" | "default" | "destructive" | "success" | "info" | "warning" | "secondary" | "dark";
     color?: string;
     size?: "sm" | "md" | "lg" | "xl";
-    body?: string;
-    sub?: string;
+    body?: ReactNode;
+    sub?: ReactNode;
     confirmButton?: string | "Confirm";
     cancelButton?: string | "Cancel";
   };

--- a/app/[lang]/(dashboard)/(settings)/(menus)/_components/menu-manage/menu-manage.tsx
+++ b/app/[lang]/(dashboard)/(settings)/(menus)/_components/menu-manage/menu-manage.tsx
@@ -21,6 +21,7 @@ const MenuManagement: React.FC = () => {
   const [currentDropZone, setCurrentDropZone] = useState<DropZone | null>(null);
   const [expandedItems, setExpandedItems] = useState<Set<number>>(new Set());
   const [openModal, setOpenModal] = useState(false);
+  const [openResetModal, setOpenResetModal] = useState(false);
   const [selectedItem, setSelectedItem] = useState<MenuItem | null>(null);
   const [search, setSearch] = useState("");
   const [statusVal, setStatusVal] = useState("");
@@ -28,9 +29,10 @@ const MenuManagement: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [deletedItems, setDeletedItems] = useState<Set<number>>(new Set());
   const [openSuccessModal, setOpenSuccessModal] = useState(false);
-  let confirmDialogConfig = {};
+  let deleteDialogConfig = {};
+  let resetDialogConfig = {};
   let successDialogConfig = {};
-  confirmDialogConfig = {
+  deleteDialogConfig = {
     title: "Confirm Delete Service?",
     icon: "stash:question",
     class: "destructive",
@@ -38,6 +40,17 @@ const MenuManagement: React.FC = () => {
     body: "Do you want to delete this service?",
     sub: "Deleting this item is irreversible. Are you sure you want to continue?",
     confirmButton: "Yes, Delete",
+    cancelButton: "Cancel",
+  };
+
+  resetDialogConfig = {
+    title: "Reset Menu Changes?",
+    icon: "stash:question",
+    class: "destructive",
+    color: "#EF4444",
+    body: "This will restore the original menu structure.",
+    sub: "All unsaved changes will be lost. Continue?",
+    confirmButton: "Yes, Reset",
     cancelButton: "Cancel",
   };
 
@@ -147,6 +160,12 @@ const MenuManagement: React.FC = () => {
     setOpenModal(false);
     setDeletedItems(prev => new Set([...prev, selectedItem.id]));
     setSelectedItem(null);
+  };
+
+  const handleResetConfirm = (): void => {
+    setMenusList(JSON.parse(JSON.stringify(originalMenus)));
+    setDeletedItems(new Set());
+    setOpenResetModal(false);
   };
   // const handleDelete = (item: MenuItem): void => {
   //   if (item.children && item.children.length > 0) {
@@ -687,10 +706,7 @@ const MenuManagement: React.FC = () => {
   };
 
   const resetMenu = () => {
-    if (confirm("Reset all changes and restore original menu structure?")) {
-      setMenusList(JSON.parse(JSON.stringify(originalMenus))); // Deep clone
-      setDeletedItems(new Set()); // Clear deleted items
-    }
+    setOpenResetModal(true);
   };
 
   const saveChanges = async () => {
@@ -776,7 +792,15 @@ const MenuManagement: React.FC = () => {
           open={openModal}
           onOpenChange={setOpenModal}
           onConfirm={handleConfirm}
-          dialogConfig={confirmDialogConfig}
+          dialogConfig={deleteDialogConfig}
+        />
+      )}
+      {openResetModal && (
+        <ConfirmDialog
+          open={openResetModal}
+          onOpenChange={setOpenResetModal}
+          onConfirm={handleResetConfirm}
+          dialogConfig={resetDialogConfig}
         />
       )}
       {openSuccessModal && <SuccessDialog open={openSuccessModal} onOpenChange={setOpenSuccessModal} dialogConfig={successDialogConfig} />}

--- a/app/[lang]/(dashboard)/(settings)/(menus)/_components/menu-manage/menu-manage.tsx
+++ b/app/[lang]/(dashboard)/(settings)/(menus)/_components/menu-manage/menu-manage.tsx
@@ -29,9 +29,11 @@ const MenuManagement: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [deletedItems, setDeletedItems] = useState<Set<number>>(new Set());
   const [openSuccessModal, setOpenSuccessModal] = useState(false);
+  const [openSuccessResetModal, setOpenSuccessResetModal] = useState(false);
   let deleteDialogConfig = {};
   let resetDialogConfig = {};
   let successDialogConfig = {};
+  let successResetDialogConfig = {};
   deleteDialogConfig = {
     title: "Confirm Delete Service?",
     icon: "stash:question",
@@ -57,6 +59,12 @@ const MenuManagement: React.FC = () => {
   successDialogConfig = {
     icon: "solar:verified-check-outline",
     body: "Delete service successfully.",
+    color: "#22C55E",
+  };
+
+  successResetDialogConfig = {
+    icon: "solar:verified-check-outline",
+    body: "Menu reset successfully.",
     color: "#22C55E",
   };
   const router = useRouter();
@@ -166,6 +174,7 @@ const MenuManagement: React.FC = () => {
     setMenusList(JSON.parse(JSON.stringify(originalMenus)));
     setDeletedItems(new Set());
     setOpenResetModal(false);
+    setOpenSuccessResetModal(true);
   };
   // const handleDelete = (item: MenuItem): void => {
   //   if (item.children && item.children.length > 0) {
@@ -804,6 +813,9 @@ const MenuManagement: React.FC = () => {
         />
       )}
       {openSuccessModal && <SuccessDialog open={openSuccessModal} onOpenChange={setOpenSuccessModal} dialogConfig={successDialogConfig} />}
+      {openSuccessResetModal && (
+        <SuccessDialog open={openSuccessResetModal} onOpenChange={setOpenSuccessResetModal} dialogConfig={successResetDialogConfig} />
+      )}
       {/* <div className="p-1 md:p-5 grid grid-cols-[auto_1fr_1fr_auto] gap-4 items-center text-default-900"> */}
       {/* <p className="">Status</p> */}
       {/* <div className=""> */}


### PR DESCRIPTION
## Summary
- share ConfirmDialog for both delete and reset actions
- make dialog body fields accept React nodes
- apply new dialog configs for delete and reset in menu management

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdfe0d70083339770c15317653675