### PR TITLE
Fix refreshToken usage

### DIFF
--- a/app/[lang]/(dashboard)/layout.tsx
+++ b/app/[lang]/(dashboard)/layout.tsx
@@ -1,7 +1,7 @@
 import DashBoardLayoutProvider from "@/provider/dashboard.layout.provider";
 import { getDictionary } from "@/app/dictionaries";
 import { cookies } from "next/headers";
-// import { refresh } from "@/config/refresh-token";
+import { refreshToken } from "@/config/refresh-token";
 import { redirect } from "next/navigation";
 
 const layout = async ({ children, params: { lang } }: { children: React.ReactNode; params: { lang: any } }) => {

--- a/config/refresh-token.ts
+++ b/config/refresh-token.ts
@@ -20,3 +20,16 @@ export async function refresh(authToken: string) {
     console.error('getAuthMe error:', error.message || error);
   }
 }
+
+export async function refreshToken(authToken: string): Promise<string | null> {
+  try {
+    const data = await refresh(authToken);
+    if (!data) {
+      return null;
+    }
+    return data.accessToken || data.token || null;
+  } catch (error: any) {
+    console.error('Token refresh error:', error.message || error);
+    return null;
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { match } from '@formatjs/intl-localematcher';
 import Negotiator from 'negotiator';
-import { refresh } from "@/config/refresh-token";
+import { refreshToken } from "@/config/refresh-token";
 
 const locales = ['en', 'th'] as const;
 const defaultLocale = 'en';
@@ -52,22 +52,7 @@ function isJwtExpired(token: string): boolean {
   }
 }
 
-// Refresh token function - you'll need to implement this based on your API
-async function refreshToken(token: string): Promise<string | null> {
-  try {
-    const response = await refresh(token)
-
-    if (!response.ok) {
-      throw new Error('Token refresh failed');
-    }
-
-    const data = await response.json();
-    return data.accessToken || data.token || null;
-  } catch (error) {
-    console.error('Token refresh error:', error);
-    return null;
-  }
-}
+// refreshToken is imported from config/refresh-token.ts
 
 // Extract locale from pathname
 function getLocaleFromPathname(pathname: string): Locale | null {


### PR DESCRIPTION
## Summary
- move refreshToken helper into `config/refresh-token.ts`
- import and use that helper in middleware and dashboard layout

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_685cc06a99bc8333ab5a2e1fb4303743