### PR TITLE
Fix refresh token route

### DIFF
--- a/app/api/refresh-token/route.ts
+++ b/app/api/refresh-token/route.ts
@@ -10,13 +10,9 @@ export async function GET(request: NextRequest) {
   const cookieNames = [
     cookieName,
     "token",
-    "userId"
+    "userId",
   ].filter(Boolean);
   console.log("cookieNames", cookieNames);
-
-  cookieNames.forEach(name => {
-    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=.tfac.or.th`;
-  });
 
   if (!token) {
     return NextResponse.redirect(new URL('/login', request.url));
@@ -31,10 +27,12 @@ export async function GET(request: NextRequest) {
   const redirectUrl = new URL(returnUrl, request.url);
   const res = NextResponse.redirect(redirectUrl);
 
-  // ✅ ลบ cookie เก่าก่อน (optional แต่ชัดเจน)
-  res.cookies.delete(cookieName);
+  // Remove existing cookies before setting the new one
+  cookieNames.forEach((name) => {
+    res.cookies.delete(name);
+  });
 
-  // ✅ เซ็ต cookie ใหม่
+  // Set the refreshed token
   res.cookies.set(cookieName, newToken, {
     httpOnly: false,
     secure: process.env.NODE_ENV === "development",


### PR DESCRIPTION
## Summary
- update refresh-token API route to use Next.js cookie utilities instead of `document.cookie`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_685e54d03ed48333880fa8994bada85f